### PR TITLE
Fix: amended "soft" reset condition (fixes #3).

### DIFF
--- a/js/AssessmentSet.js
+++ b/js/AssessmentSet.js
@@ -151,9 +151,10 @@ export default class AssessmentSet extends ScoringSet {
   }
 
   /**
-   * @override
+   * @extends
    * @fires Adapt#assessments:restored
    * @fires Adapt#scoring:assessment:restored
+   * @fires Adapt#scoring:set:restored
    */
   restore() {
     const storedData = OfflineStorage.get(saveStateName)?.[this.id];
@@ -163,7 +164,7 @@ export default class AssessmentSet extends ScoringSet {
       this.attempt.restore(data[1]);
     }
     if (this._isBackwardCompatible) Adapt.trigger('assessments:restored', this._compatibilityState, this.model);
-    Adapt.trigger('scoring:assessment:restored', this);
+    super.restore();
   }
 
   /**
@@ -181,11 +182,12 @@ export default class AssessmentSet extends ScoringSet {
   /**
    * Reset all models as configured.
    * Attempts will only be reset when using a "hard" reset.
-   * @override
+   * @extends
    * @fires Adapt#assessments:preReset
    * @fires Adapt#scoring:assessment:preReset
    * @fires Adapt#assessments:reset
    * @fires Adapt#scoring:assessment:reset
+   * @fires Adapt#scoring:set:reset
    * @fires Adapt#assessments:postReset
    * @fires Adapt#scoring:assessment:postReset
    * @returns {Promise}
@@ -200,7 +202,7 @@ export default class AssessmentSet extends ScoringSet {
     this._attempt = new Attempt(this);
     await Adapt.deferUntilCompletionChecked();
     if (this._isBackwardCompatible) Adapt.trigger('assessments:reset', this._compatibilityState, this.model);
-    Adapt.trigger('scoring:assessment:reset', this);
+    super.reset();
     if (this.canReload) {
       this.reload();
       this.attempt.start();
@@ -460,6 +462,7 @@ export default class AssessmentSet extends ScoringSet {
    * @extends
    * @fires Adapt#assessments:complete
    * @fires Adapt#scoring:assessment:complete
+   * @fires Adapt#scoring:set:complete
    */
   onCompleted() {
     if (this.attempt.isInProgress) {

--- a/js/AssessmentSet.js
+++ b/js/AssessmentSet.js
@@ -349,11 +349,11 @@ export default class AssessmentSet extends ScoringSet {
   }
 
   /**
-   * Returns whether the set contains any components configured to "soft" reset
+   * Returns whether all components are configured to "soft" reset
    * @returns {boolean}
    */
   get hasSoftReset() {
-    return (this.questions.length > 0 && this.resetConfig.questionsType === 'soft') || (this.presentationComponents.length > 0 && this.resetConfig.presentationComponentsType === 'soft');
+    return (this.questions.length > 0 && this.resetConfig.questionsType === 'soft') && (this.presentationComponents.length > 0 && this.resetConfig.presentationComponentsType === 'soft');
   }
 
   /**

--- a/js/AssessmentSet.js
+++ b/js/AssessmentSet.js
@@ -198,7 +198,7 @@ export default class AssessmentSet extends ScoringSet {
     Adapt.trigger('scoring:assessment:preReset', this);
     this.rawQuestions.forEach(model => model.reset(this.resetConfig._questionsType, true));
     this.rawPresentationComponents.forEach(model => model.reset(this.resetConfig._presentationComponentsType, true));
-    this.attempts.reset(this.hasSoftReset);
+    this.attempts.reset(this.isSoftReset);
     this._attempt = new Attempt(this);
     await Adapt.deferUntilCompletionChecked();
     if (this._isBackwardCompatible) Adapt.trigger('assessments:reset', this._compatibilityState, this.model);
@@ -352,7 +352,7 @@ export default class AssessmentSet extends ScoringSet {
    * Returns whether all components are configured to "soft" reset
    * @returns {boolean}
    */
-  get hasSoftReset() {
+  get isSoftReset() {
     return (this.questions.length > 0 && this.resetConfig.questionsType === 'soft') && (this.presentationComponents.length > 0 && this.resetConfig.presentationComponentsType === 'soft');
   }
 
@@ -399,7 +399,7 @@ export default class AssessmentSet extends ScoringSet {
   get isComplete() {
     if (this.isAwaitingChildren || !this.isAvailable) return false;
     if (this.attempt?.isInSession) return this.isAttemptComplete;
-    if (this.hasSoftReset) return this.attempts.wasComplete;
+    if (this.isSoftReset) return this.attempts.wasComplete;
     return this.trackableComponents.every(model => model.get('_isComplete'));
   }
 
@@ -414,7 +414,7 @@ export default class AssessmentSet extends ScoringSet {
     const isComplete = this.isComplete;
     if (this.attempt?.isInProgress && !isComplete) return false; // must be completed to pass
     if (!this.passmark.isEnabled && isComplete) return true; // always pass if complete and passmark is disabled
-    if (!this.attempt?.isInSession && this.hasSoftReset) return this.attempts.wasPassed;
+    if (!this.attempt?.isInSession && this.isSoftReset) return this.attempts.wasPassed;
     const isScaled = this.passmark.isScaled;
     const score = (isScaled) ? this.scaledScore : this.score;
     const correctness = (isScaled) ? this.scaledCorrectness : this.correctness;


### PR DESCRIPTION
Fixes #3.
Fixes https://github.com/adaptlearning/adapt-contrib-scoringAssessment/issues/2.

### Fix
* Amended "soft" reset logic so all associated components have to be configured for a "soft" reset, to allow an assessment to remain complete following a reset.
* Ensure all reset and restore events are triggered

### Dependency
* https://github.com/adaptlearning/adapt-contrib-scoring/pull/9
