### PR TITLE
Fix:  call reset and restore event triggers; amended "soft" reset condition; prevent `reload` from being called when an assessment is launched

### DIFF
--- a/js/AssessmentSet.js
+++ b/js/AssessmentSet.js
@@ -198,7 +198,7 @@ export default class AssessmentSet extends ScoringSet {
     Adapt.trigger('scoring:assessment:preReset', this);
     this.rawQuestions.forEach(model => model.reset(this.resetConfig._questionsType, true));
     this.rawPresentationComponents.forEach(model => model.reset(this.resetConfig._presentationComponentsType, true));
-    this.attempts.reset(this.iSoftReset);
+    this.attempts.reset(this.isSoftReset);
     this._attempt = new Attempt(this);
     await Adapt.deferUntilCompletionChecked();
     if (this._isBackwardCompatible) Adapt.trigger('assessments:reset', this._compatibilityState, this.model);
@@ -400,7 +400,7 @@ export default class AssessmentSet extends ScoringSet {
   get isComplete() {
     if (this.isAwaitingChildren || !this.isAvailable) return false;
     if (this.attempt?.isInSession) return this.isAttemptComplete;
-    if (this.iSoftReset) return this.attempts.wasComplete;
+    if (this.isSoftReset) return this.attempts.wasComplete;
     return this.trackableComponents.every(model => model.get('_isComplete'));
   }
 
@@ -415,7 +415,7 @@ export default class AssessmentSet extends ScoringSet {
     const isComplete = this.isComplete;
     if (this.attempt?.isInProgress && !isComplete) return false; // must be completed to pass
     if (!this.passmark.isEnabled && isComplete) return true; // always pass if complete and passmark is disabled
-    if (!this.attempt?.isInSession && this.iSoftReset) return this.attempts.wasPassed;
+    if (!this.attempt?.isInSession && this.isSoftReset) return this.attempts.wasPassed;
     const isScaled = this.passmark.isScaled;
     const score = (isScaled) ? this.scaledScore : this.score;
     const correctness = (isScaled) ? this.scaledCorrectness : this.correctness;

--- a/js/AssessmentSet.js
+++ b/js/AssessmentSet.js
@@ -151,9 +151,10 @@ export default class AssessmentSet extends ScoringSet {
   }
 
   /**
-   * @override
+   * @extends
    * @fires Adapt#assessments:restored
    * @fires Adapt#scoring:assessment:restored
+   * @fires Adapt#scoring:set:restored
    */
   restore() {
     const storedData = OfflineStorage.get(saveStateName)?.[this.id];
@@ -163,7 +164,7 @@ export default class AssessmentSet extends ScoringSet {
       this.attempt.restore(data[1]);
     }
     if (this._isBackwardCompatible) Adapt.trigger('assessments:restored', this._compatibilityState, this.model);
-    Adapt.trigger('scoring:assessment:restored', this);
+    super.restore();
   }
 
   /**
@@ -181,11 +182,12 @@ export default class AssessmentSet extends ScoringSet {
   /**
    * Reset all models as configured.
    * Attempts will only be reset when using a "hard" reset.
-   * @override
+   * @extends
    * @fires Adapt#assessments:preReset
    * @fires Adapt#scoring:assessment:preReset
    * @fires Adapt#assessments:reset
    * @fires Adapt#scoring:assessment:reset
+   * @fires Adapt#scoring:set:reset
    * @fires Adapt#assessments:postReset
    * @fires Adapt#scoring:assessment:postReset
    * @returns {Promise}
@@ -200,7 +202,7 @@ export default class AssessmentSet extends ScoringSet {
     this._attempt = new Attempt(this);
     await Adapt.deferUntilCompletionChecked();
     if (this._isBackwardCompatible) Adapt.trigger('assessments:reset', this._compatibilityState, this.model);
-    Adapt.trigger('scoring:assessment:reset', this);
+    super.reset();
     if (this.canReload) {
       this.reload();
       this.attempt.start();
@@ -460,6 +462,7 @@ export default class AssessmentSet extends ScoringSet {
    * @extends
    * @fires Adapt#assessments:complete
    * @fires Adapt#scoring:assessment:complete
+   * @fires Adapt#scoring:set:complete
    */
   onCompleted() {
     if (this.attempt.isInProgress) {

--- a/js/AssessmentSet.js
+++ b/js/AssessmentSet.js
@@ -203,10 +203,7 @@ export default class AssessmentSet extends ScoringSet {
     await Adapt.deferUntilCompletionChecked();
     if (this._isBackwardCompatible) Adapt.trigger('assessments:reset', this._compatibilityState, this.model);
     super.reset();
-    if (this.canReload) {
-      this.reload();
-      this.attempt.start();
-    }
+    if (this.canReload) this.reload();
     _.defer(() => {
       if (this._isBackwardCompatible) Adapt.trigger('assessments:postReset', this._compatibilityState, this.model);
       Adapt.trigger('scoring:assessment:postReset', this);
@@ -363,7 +360,7 @@ export default class AssessmentSet extends ScoringSet {
   get canReload() {
     const pageId = this.model.findAncestor('page')?.get('_id');
     const locationId = Location._currentId;
-    return (pageId === locationId);
+    return pageId === locationId && this.model.get('_isRendered');
   }
 
   /**

--- a/js/AssessmentSet.js
+++ b/js/AssessmentSet.js
@@ -349,11 +349,11 @@ export default class AssessmentSet extends ScoringSet {
   }
 
   /**
-   * Returns whether the set contains any components configured to "soft" reset
+   * Returns whether all components are configured to "soft" reset
    * @returns {boolean}
    */
   get hasSoftReset() {
-    return (this.questions.length > 0 && this.resetConfig.questionsType === 'soft') || (this.presentationComponents.length > 0 && this.resetConfig.presentationComponentsType === 'soft');
+    return (this.questions.length > 0 && this.resetConfig.questionsType === 'soft') && (this.presentationComponents.length > 0 && this.resetConfig.presentationComponentsType === 'soft');
   }
 
   /**

--- a/js/AssessmentSet.js
+++ b/js/AssessmentSet.js
@@ -44,7 +44,7 @@ export default class AssessmentSet extends ScoringSet {
   }
 
   /**
-   * @extends
+   * @override
    */
   register() {
     if (this._isBackwardCompatible) Adapt.trigger('assessments:register', this._compatibilityState, this.model);
@@ -80,7 +80,7 @@ export default class AssessmentSet extends ScoringSet {
   }
 
   /**
-   * @extends
+   * @override
    */
   _setupListeners() {
     super._setupListeners();
@@ -151,7 +151,7 @@ export default class AssessmentSet extends ScoringSet {
   }
 
   /**
-   * @extends
+   * @override
    * @fires Adapt#assessments:restored
    * @fires Adapt#scoring:assessment:restored
    * @fires Adapt#scoring:set:restored
@@ -168,7 +168,7 @@ export default class AssessmentSet extends ScoringSet {
   }
 
   /**
-   * @extends
+   * @override
    */
   update() {
     Logging.debug(`${this.id} minScore: ${this.minScore}, maxScore: ${this.maxScore}`);
@@ -182,7 +182,7 @@ export default class AssessmentSet extends ScoringSet {
   /**
    * Reset all models as configured.
    * Attempts will only be reset when using a "hard" reset.
-   * @extends
+   * @override
    * @fires Adapt#assessments:preReset
    * @fires Adapt#scoring:assessment:preReset
    * @fires Adapt#assessments:reset
@@ -198,7 +198,7 @@ export default class AssessmentSet extends ScoringSet {
     Adapt.trigger('scoring:assessment:preReset', this);
     this.rawQuestions.forEach(model => model.reset(this.resetConfig._questionsType, true));
     this.rawPresentationComponents.forEach(model => model.reset(this.resetConfig._presentationComponentsType, true));
-    this.attempts.reset(this.hasSoftReset);
+    this.attempts.reset(this.iSoftReset);
     this._attempt = new Attempt(this);
     await Adapt.deferUntilCompletionChecked();
     if (this._isBackwardCompatible) Adapt.trigger('assessments:reset', this._compatibilityState, this.model);
@@ -255,7 +255,7 @@ export default class AssessmentSet extends ScoringSet {
   }
 
   /**
-   * @extends
+   * @override
    */
   get minScore() {
     if (this.isComplete && !this.attempt?.isInSession) return this.attempts.last.minScore;
@@ -263,7 +263,7 @@ export default class AssessmentSet extends ScoringSet {
   }
 
   /**
-   * @extends
+   * @override
    */
   get maxScore() {
     if (this.isComplete && !this.attempt?.isInSession) return this.attempts.last.maxScore;
@@ -271,7 +271,7 @@ export default class AssessmentSet extends ScoringSet {
   }
 
   /**
-   * @extends
+   * @override
    */
   get score() {
     if (this.isComplete && !this.attempt?.isInSession) return this.attempts.last.score;
@@ -279,7 +279,7 @@ export default class AssessmentSet extends ScoringSet {
   }
 
   /**
-   * @extends
+   * @override
    */
   get correctness() {
     if (this.isComplete && !this.attempt?.isInSession) return this.attempts.last.correctness;
@@ -349,8 +349,12 @@ export default class AssessmentSet extends ScoringSet {
    * Returns whether all components are configured to "soft" reset
    * @returns {boolean}
    */
-  get hasSoftReset() {
-    return (this.questions.length > 0 && this.resetConfig.questionsType === 'soft') && (this.presentationComponents.length > 0 && this.resetConfig.presentationComponentsType === 'soft');
+  get isSoftReset() {
+    const hasQuestions = this.questions.length > 0;
+    const hasPresentationComponents = this.presentationComponents.length > 0;
+    const hasQuestionsSoftReset = !hasQuestions || this.resetConfig.questionsType === 'soft';
+    const hasPresentationComponentsSoftReset = !hasPresentationComponents || this.resetConfig.presentationComponentsType === 'soft';
+    return hasQuestionsSoftReset && hasPresentationComponentsSoftReset;
   }
 
   /**
@@ -396,7 +400,7 @@ export default class AssessmentSet extends ScoringSet {
   get isComplete() {
     if (this.isAwaitingChildren || !this.isAvailable) return false;
     if (this.attempt?.isInSession) return this.isAttemptComplete;
-    if (this.hasSoftReset) return this.attempts.wasComplete;
+    if (this.iSoftReset) return this.attempts.wasComplete;
     return this.trackableComponents.every(model => model.get('_isComplete'));
   }
 
@@ -411,7 +415,7 @@ export default class AssessmentSet extends ScoringSet {
     const isComplete = this.isComplete;
     if (this.attempt?.isInProgress && !isComplete) return false; // must be completed to pass
     if (!this.passmark.isEnabled && isComplete) return true; // always pass if complete and passmark is disabled
-    if (!this.attempt?.isInSession && this.hasSoftReset) return this.attempts.wasPassed;
+    if (!this.attempt?.isInSession && this.iSoftReset) return this.attempts.wasPassed;
     const isScaled = this.passmark.isScaled;
     const score = (isScaled) ? this.scaledScore : this.score;
     const correctness = (isScaled) ? this.scaledCorrectness : this.correctness;
@@ -456,7 +460,7 @@ export default class AssessmentSet extends ScoringSet {
   }
 
   /**
-   * @extends
+   * @override
    * @fires Adapt#assessments:complete
    * @fires Adapt#scoring:assessment:complete
    * @fires Adapt#scoring:set:complete


### PR DESCRIPTION
Fixes #2, #3, #4.

### Fix
* Amended "soft" reset logic so all associated components have to be configured for a "soft" reset, to allow an assessment to remain complete following a reset.
* Ensure all reset and restore events are triggered
* Prevent `reload` from being called when an assessment is launched, which broke the navigation back button.

### Dependency
* https://github.com/adaptlearning/adapt-contrib-scoring/pull/9

