### PR TITLE
Fix: find all intersected sets regardless of availablility

### DIFF
--- a/js/AssessmentSet.js
+++ b/js/AssessmentSet.js
@@ -56,8 +56,7 @@ export default class AssessmentSet extends ScoringSet {
    * @private
    */
   _setModelsOwnership() {
-    const models = this.model.getChildren().models;
-    models.forEach(model => model.setOnChildren({
+    this.rawModels.forEach(model => model.setOnChildren({
       _isPartOfAssessment: true
     }));
   }
@@ -242,8 +241,15 @@ export default class AssessmentSet extends ScoringSet {
   /**
    * @override
    */
+  get rawModels() {
+    return this.model.getChildren().models;
+  }
+
+  /**
+   * @override
+   */
   get models() {
-    return this.filterModels(this.model.getChildren().models);
+    return this.filterModels(this.rawModels);
   }
 
   /**


### PR DESCRIPTION
Fixes #15.

### Fix
* Add `rawModels` to resolve inconsistency with intersection queries and available subsets.
* Allows sets to `update` to availability changes on their intersections.

### Dependency
* https://github.com/adaptlearning/adapt-contrib-scoring/pull/21


