### PR TITLE
Update: align unavailable objectives logic with `ScoringSet`

### DIFF
--- a/js/AssessmentSet.js
+++ b/js/AssessmentSet.js
@@ -174,7 +174,7 @@ export default class AssessmentSet extends ScoringSet {
     Logging.debug(`${this.id} minScore: ${this.minScore}, maxScore: ${this.maxScore}`);
     Logging.debug(`${this.id} score: ${this.score}, scaledScore: ${this.scaledScore}`);
     Logging.debug(`${this.id} isAttemptComplete: ${this.isAttemptComplete}, isComplete: ${this.isComplete}, isPassed: ${this.isPassed}`);
-    if (this.attempt) this.attempt.updateScore();
+    this.attempt?.update();
     super.update();
     if (Adapt.get('_isStarted')) this.save();
   }
@@ -368,6 +368,15 @@ export default class AssessmentSet extends ScoringSet {
   }
 
   /**
+   * Return the attempt currently being used for the objective
+   * @returns {Attempt}
+   */
+  get objectiveAttempt() {
+    if (this.attempts.used >= 1 && this.isSoftReset) return this.attempts.best;
+    return this.attempt;
+  }
+
+  /**
    * @override
    */
   get isOptional() {
@@ -382,12 +391,29 @@ export default class AssessmentSet extends ScoringSet {
   }
 
   /**
+   * @override
+   */
+  get isStarted() {
+    return this.model.get('_isVisited');
+  }
+
+  /**
    * Returns whether all components have been completed in the last attempt
    * @returns {boolean}
    */
   get isAttemptComplete() {
     if (this.isAwaitingChildren || !this.isAvailable) return false;
     return this.trackableComponents.every(model => model.get('_isInteractionComplete'));
+  }
+
+  /**
+   * Returns whether the objective for the assessment is completed.
+   * A previously completed assessment which has been "soft" reset, will remain completed.
+   * @override
+   * @returns {boolean}
+   */
+  get isObjectiveComplete() {
+    return this.objectiveAttempt.isComplete;
   }
 
   /**
@@ -402,6 +428,16 @@ export default class AssessmentSet extends ScoringSet {
     if (this.attempt?.isInSession) return this.isAttemptComplete;
     if (this.isSoftReset) return this.attempts.wasComplete;
     return this.trackableComponents.every(model => model.get('_isComplete'));
+  }
+
+  /**
+   * Returns whether the objective for the assessment is passed.
+   * A previously completed assessment which has been "soft" reset, will remain passed.
+   * @override
+   * @returns {boolean}
+   */
+  get isObjectivePassed() {
+    return this.objectiveAttempt.isPassed;
   }
 
   /**
@@ -432,6 +468,17 @@ export default class AssessmentSet extends ScoringSet {
       this.attempts.saveState,
       this.attempt.saveState
     ];
+  }
+
+  /**
+   * Complete the assessment objective.
+   * Only update the record with the best attempt when using "soft" reset.
+   * @override
+   */
+  _completeObjective() {
+    if (this.subsetParent || (this.attempts.used > 1 && this.attempt?.isInSession && this.isSoftReset && !this.attempts.isBestAttempt(this.attempt))) return;
+    this._setObjectiveScore();
+    this._setObjectiveStatus();
   }
 
   /**

--- a/js/Attempt.js
+++ b/js/Attempt.js
@@ -1,4 +1,7 @@
 import data from 'core/js/data';
+import {
+  getScaledScoreFromMinMax
+} from 'extensions/adapt-contrib-scoring/js/adapt-contrib-scoring';
 
 export default class Attempt {
 
@@ -20,9 +23,10 @@ export default class Attempt {
   }
 
   /**
-   * Update the attempt scores
+   * Update the attempt
    */
-  updateScore() {
+  update() {
+    if (!this.isInProgress) return;
     this._minScore = this._assessment.minScore;
     this._maxScore = this._assessment.maxScore;
     this._score = this._assessment.score;
@@ -70,6 +74,7 @@ export default class Attempt {
     this._correctness = 0;
     this._isComplete = false;
     this._isPassed = false;
+    this._questionTrackingPositions = [];
   }
 
   /**
@@ -118,6 +123,14 @@ export default class Attempt {
    */
   get score() {
     return this._score;
+  }
+
+  /**
+   * Returns a percentage score relative to a positive minimum or zero and maximum values
+   * @returns {number}
+   */
+  get scaledScore() {
+    return getScaledScoreFromMinMax(this.score, this.minScore, this.maxScore);
   }
 
   /**

--- a/js/Attempts.js
+++ b/js/Attempts.js
@@ -9,7 +9,7 @@ export default class Attempts {
     this._limit = _limit === 'infinite' ? -1 : parseInt(_limit);
     this._used = 0;
     this._shouldStoreAttempts = _shouldStoreAttempts;
-    this._best;
+    this._best = null;
     this._history = [];
     this._assessment = assessment;
   }
@@ -30,7 +30,7 @@ export default class Attempts {
    */
   record(attempt) {
     if (!this._shouldStoreAttempts && this.last) this.reset();
-    if (attempt.score > (this.best?.score || Number.MIN_SAFE_INTEGER)) this._best = attempt;
+    if (this.isAttemptBetter(attempt)) this._best = attempt;
     this._history.push(attempt);
   }
 
@@ -55,6 +55,7 @@ export default class Attempts {
    * Reset the attempts unless `_shouldStoreAttempts`.
    * A "soft" reset will maintain the last attempt for maintaining state.
    * @todo Reset best attempt if "hard" reset?
+   * @param {boolean} isSoft
    */
   reset(isSoft = false) {
     if (this._shouldStoreAttempts) return;
@@ -63,6 +64,24 @@ export default class Attempts {
     } else if (this.history.length > 1) {
       this._history = this.history.pop();
     }
+  }
+
+  /**
+   * Returns whether the attempt is better than the current best
+   * @param {Attempt} attempt
+   * @returns {boolean}
+   */
+  isAttemptBetter(attempt) {
+    return attempt.scaledScore > (this.best?.scaledScore || Number.MIN_SAFE_INTEGER);
+  }
+
+  /**
+   * Returns whether the attempt is the best
+   * @param {Attempt} attempt
+   * @returns {boolean}
+   */
+  isBestAttempt(attempt) {
+    return attempt === this.best;
   }
 
   /**
@@ -115,13 +134,15 @@ export default class Attempts {
 
   /**
    * Returns the last completed attempt
-   */
+  * @returns {Attempt}
+  */
   get last() {
     return this.history[this.history.length - 1];
   }
 
   /**
    * Returns the best attempt
+   * @returns {Attempt}
    */
   get best() {
     return this._best;


### PR DESCRIPTION
Fixes #14.

### Fix
* Prevent an attempt no longer in progress from being reset if the set becomes unavailable

### Update
* Update unavailable objective logic to align with `ScoringSet`

### Dependency
* https://github.com/adaptlearning/adapt-contrib-scoring/pull/22
* https://github.com/adaptlearning/adapt-contrib-scoringAssessment/pull/16


